### PR TITLE
Stellar SDK 0.18 support and backfill work

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,2 +1,3 @@
 language: java
-
+jdk:
+  - openjdk8

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Documentation:
 | ManageBuyOfferOperationMapper           | ManageBuyOfferOperationResponse           | Operation.manageBuyOffer           | MANAGE_BUY_OFFER          | 12 |          |
 | ManageDataOperationMapper               | ManageDataOperationResponse               | Operation.manageData               | MANAGE_DATA               | 10 |          |
 | ManageSellOfferOperationMapper          | ManageSellOfferOperationResponse          | Operation.manageSellOffer          | MANAGE_SELL_OFFER         |  3 |          |
-| PathPaymentOperationMapper              | PathPaymentOperationResponse              | Operation.pathPaymentStrictReceive | PATH_PAYMENT              |  2 |   True   |
+| PathPaymentOperationMapper              | PathPaymentStrictReceiveOperationResponse | Operation.pathPaymentStrictReceive | PATH_PAYMENT              |  2 |   True   |
 | PathPaymentStrictReceiveOperationMapper | PathPaymentStrictReceiveOperationResponse | Operation.pathPaymentStrictReceive | PATH_PAYMENT              |  2 |   True   |
 | PathPaymentStrictSendOperationMapper    | PathPaymentStrictSendOperationResponse    | Operation.pathPaymentStrictSend    | PATH_PAYMENT              |  2 |   True   |
 | PaymentOperationMapper                  | PaymentOperationResponse                  | Operation.payment                  | PAYMENT                   |  1 |   True   |

--- a/pom.xml
+++ b/pom.xml
@@ -32,7 +32,7 @@
 
         <fasterxml.jackson.version>2.10.1</fasterxml.jackson.version>
         <spring.boot.version>2.2.1.RELEASE</spring.boot.version>
-        <stellar.sdk.version>0.10.0</stellar.sdk.version>
+        <stellar.sdk.version>0.18.0</stellar.sdk.version>
     </properties>
 
     <repositories>

--- a/src/main/java/io/amberdata/inbound/stellar/client/HorizonServer.java
+++ b/src/main/java/io/amberdata/inbound/stellar/client/HorizonServer.java
@@ -1,6 +1,9 @@
 package io.amberdata.inbound.stellar.client;
 
 import java.io.IOException;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -9,6 +12,14 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
 import org.stellar.sdk.Server;
+import org.stellar.sdk.requests.ClientIdentificationInterceptor;
+import org.stellar.sdk.requests.ErrorResponse;
+import org.stellar.sdk.responses.AccountResponse;
+
+import shadow.okhttp3.Interceptor;
+import shadow.okhttp3.OkHttpClient;
+import shadow.okhttp3.Request;
+import shadow.okhttp3.Response;
 
 @Component
 public class HorizonServer {
@@ -17,6 +28,29 @@ public class HorizonServer {
 
   private final Server horizonServer;
   private final String serverUrl;
+
+  private Set<String> missingAddresses;
+  private Set<String> knownAddresses;
+
+  private LruCache<String, AccountResponse> addressCache;
+  private long cacheCreationTime;
+  private static final int MAX_ADDRESS_CACHE_SIZE = 1024;
+  private static final int MAX_ADDRESS_CACHE_AGE_MILLIS = 3600000;
+
+  public static final int HORIZON_PER_REQUEST_LIMIT = 200;
+
+  // Helper to profile every URL hit by Stellar Java SDK to check how performance can be improved.
+  private class LogInterceptor implements Interceptor {
+    @Override
+    public Response intercept(Interceptor.Chain chain) throws IOException {
+      final Request req = chain.request();
+      final long start = System.currentTimeMillis();
+      final Response resp = chain.proceed(chain.request());
+      LOG.info("request url: {} method: {} duration: {}ms",
+          req.url().toString(), req.method(), (System.currentTimeMillis() - start));
+      return resp;
+    }
+  }
 
   /**
    * Default constructor.
@@ -27,7 +61,31 @@ public class HorizonServer {
     LOG.info("Horizon server URL {}", serverUrl);
 
     this.serverUrl = serverUrl;
-    this.horizonServer = new Server(serverUrl);
+    this.missingAddresses = new HashSet<>();
+    this.knownAddresses = new HashSet<>();
+    this.addressCache = new LruCache<>(MAX_ADDRESS_CACHE_SIZE);
+    this.cacheCreationTime = System.currentTimeMillis();
+
+    // Stolen from the regular constructor for Server, but increasing
+    // |readTimeout| to 90 and 120 seconds respectively since our
+    // Horizon/PostgreSQL setup can be pokey
+    final OkHttpClient httpClient = new OkHttpClient.Builder()
+        .addInterceptor(new ClientIdentificationInterceptor())
+        //.addInterceptor(new LogInterceptor())
+        .connectTimeout(10, TimeUnit.SECONDS)
+        .readTimeout(90, TimeUnit.SECONDS)
+        .retryOnConnectionFailure(true)
+        .build();
+
+    final OkHttpClient submitHttpClient = new OkHttpClient.Builder()
+        .addInterceptor(new ClientIdentificationInterceptor())
+        //.addInterceptor(new LogInterceptor())
+        .connectTimeout(10, TimeUnit.SECONDS)
+        .readTimeout(120, TimeUnit.SECONDS)
+        .retryOnConnectionFailure(true)
+        .build();
+
+    this.horizonServer = new Server(serverUrl, httpClient, submitHttpClient);
   }
 
   /**
@@ -85,4 +143,60 @@ public class HorizonServer {
     }
   }
 
+  /**
+   * Caching wrapper around fetching details from Horizon about a given Stellar
+   * account. The cache is blown away every 2 hours.
+   * TODO: Blow things away on a key age basis rather than all at once.
+   *
+   * @param accountId The alphanumeric account ID to fetch details for.
+   *
+   * @return the url of the server.
+   */
+  public AccountResponse fetchAccountDetails(String accountId) {
+    final long now = System.currentTimeMillis();
+    if (now - this.cacheCreationTime > MAX_ADDRESS_CACHE_AGE_MILLIS) {
+      // Intentionally do not clear this.knownAddresses.
+      this.missingAddresses = new HashSet<>();
+      this.addressCache = new LruCache<>(MAX_ADDRESS_CACHE_SIZE);
+      this.cacheCreationTime = now;
+    }
+
+    // We already requested this address and it is not found. Skip the request.
+    if (missingAddresses.contains(accountId)) {
+      return null;
+    } else if (!knownAddresses.contains(accountId)) {
+      knownAddresses.add(accountId);
+      Metrics.count("account.unique", 1);
+    } else if (addressCache.containsKey(accountId)) {
+      Metrics.count("account.cache.hit", 1);
+      return addressCache.get(accountId);
+    }
+
+    Metrics.count("account.cache.miss", 1);
+    try {
+      final AccountResponse resp = this.horizonServer()
+          .accounts()
+          .account(accountId);
+
+      addressCache.put(accountId, resp);
+      return resp;
+    } catch (Exception e) {
+      if (e instanceof ErrorResponse) {
+        ErrorResponse er = (ErrorResponse)e;
+        if (er.getCode() == 404) {
+          LOG.info("Ignoring not found account ID: {}", accountId);
+          missingAddresses.add(accountId);
+          Metrics.count("account.errors.not_found", 1);
+        } else {
+          LOG.error("Unable to get details for account ID ({}): {}: {}",
+              er.getCode(), accountId, er.getBody());
+          Metrics.count("account.errors.other_http", 1);
+        }
+      } else {
+        LOG.error("Unable to get details for account ID: {}", accountId, e);
+        Metrics.count("account.errors.other", 1);
+      }
+      return null;
+    }
+  }
 }

--- a/src/main/java/io/amberdata/inbound/stellar/client/LruCache.java
+++ b/src/main/java/io/amberdata/inbound/stellar/client/LruCache.java
@@ -1,0 +1,17 @@
+package io.amberdata.inbound.stellar.client;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+public class LruCache<K, V> extends LinkedHashMap<K, V> {
+  private int capacity;
+
+  public LruCache(int capacity) {
+    this.capacity = capacity;
+  }
+
+  @Override
+  protected boolean removeEldestEntry(Map.Entry<K, V> eldest) {
+    return this.size() > this.capacity;
+  }
+}

--- a/src/main/java/io/amberdata/inbound/stellar/client/Metrics.java
+++ b/src/main/java/io/amberdata/inbound/stellar/client/Metrics.java
@@ -1,0 +1,93 @@
+package io.amberdata.inbound.stellar.client;
+
+import java.util.HashMap;
+import java.util.LinkedList;
+import java.util.Map;
+import java.util.TreeMap;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class Metrics {
+  private static final Logger LOG = LoggerFactory.getLogger(Metrics.class);
+  private static final Map<String, Double> metrics = new TreeMap<>();
+  private static final Map<String, LinkedList<Double>> samples = new HashMap<>();
+  private static long lastPrint = System.currentTimeMillis();
+
+  private static final long PRINT_DELAY_MILLIS = 30 * 1000;
+  private static final int MAX_SAMPLE_COUNT = 16;
+
+  /**
+   * Adds the value to the metric identified by the metric key.
+   *
+   * @param metric The metric key.
+   * @param value  The value to add to it (or initially set to if non-existent)
+   */
+  public static void count(String metric, double value) {
+    final double newValue = metrics.getOrDefault(metric, 0.) + 1;
+    metrics.put(metric, newValue);
+    maybeLog();
+  }
+
+  /**
+   * Sets the value of the metric identified by the metric key.
+   *
+   * @param metric The metric key.
+   * @param value  The value to set that metric to.
+   */
+  public static void gauge(String metric, double value) {
+    metrics.put(metric, value);
+    maybeLog();
+  }
+
+  /**
+   * Adds the value into a running list of samples for that metric key,
+   * sets the metric to the mean over all samples.
+   *
+   * @param metric The metric key.
+   * @param value  The value to add as a sample for mean calculation.
+   */
+  public static void mean(String metric, double value) {
+    LinkedList<Double> metricSamples;
+
+    if (samples.containsKey(metric)) {
+      metricSamples = samples.get(metric);
+    } else {
+      metricSamples = new LinkedList<>();
+    }
+
+    // Keep a lookback of only MAX_SAMPLE_COUNT samples.
+    metricSamples.add(value);
+    if (metricSamples.size() > MAX_SAMPLE_COUNT) {
+      metricSamples.removeFirst();
+    }
+    samples.put(metric, metricSamples);
+
+    // Calculate mean, min, max over all samples.
+    double sum = 0;
+    Double max = null;
+    Double min = null;
+
+    for (double i : metricSamples) {
+      sum += i;
+      if (max == null || i > max) {
+        max = i;
+      }
+      if (min == null || i < min) {
+        min = i;
+      }
+    }
+
+    gauge(metric + ".mean", sum / metricSamples.size());
+    gauge(metric + ".min", min);
+    gauge(metric + ".max", max);
+  }
+
+  private static void maybeLog() {
+    final long now = System.currentTimeMillis();
+    if (now - lastPrint > PRINT_DELAY_MILLIS) {
+      LOG.info("[METRICS] " + metrics);
+      lastPrint = now;
+    }
+  }
+}

--- a/src/main/java/io/amberdata/inbound/stellar/configuration/history/HistoricalManager.java
+++ b/src/main/java/io/amberdata/inbound/stellar/configuration/history/HistoricalManager.java
@@ -141,6 +141,7 @@ public class HistoricalManager {
         Page<TransactionResponse> transactionsPage = this.horizonServer.transactions()
             .forLedger(seqNumber)
             .order(RequestBuilder.Order.ASC)
+            .limit(HorizonServer.HORIZON_PER_REQUEST_LIMIT)
             .execute();
 
         transactions = transactionsPage.getRecords();

--- a/src/main/java/io/amberdata/inbound/stellar/configuration/subscribers/AccountSubscriberConfiguration.java
+++ b/src/main/java/io/amberdata/inbound/stellar/configuration/subscribers/AccountSubscriberConfiguration.java
@@ -115,7 +115,7 @@ public class AccountSubscriberConfiguration {
       List<OperationResponse> operationResponses,
       TransactionResponse     transactionResponse
   ) {
-    return this.modelMapper.mapOperations(operationResponses, null)
+    return this.modelMapper.mapOperations(operationResponses, null, null)
       .stream()
       .flatMap(
         functionCall -> {
@@ -162,6 +162,7 @@ public class AccountSubscriberConfiguration {
     this.server.horizonServer()
         .transactions()
         .cursor(cursorPointer)
+        .limit(HorizonServer.HORIZON_PER_REQUEST_LIMIT)
         .stream(new EventListener<TransactionResponse>() {
           @Override
           public void onEvent(TransactionResponse transactionResponse) {
@@ -194,7 +195,9 @@ public class AccountSubscriberConfiguration {
         this.server.horizonServer()
           .operations()
           .forTransaction(transactionResponse.getHash())
-          .execute()
+          .limit(HorizonServer.HORIZON_PER_REQUEST_LIMIT)
+          .execute(),
+        "transaction.operations"
       );
     } catch (IOException | FormatException e) {
       LOG.error(

--- a/src/main/java/io/amberdata/inbound/stellar/configuration/subscribers/AssetSubscriberConfiguration.java
+++ b/src/main/java/io/amberdata/inbound/stellar/configuration/subscribers/AssetSubscriberConfiguration.java
@@ -137,7 +137,9 @@ public class AssetSubscriberConfiguration {
         this.server.horizonServer()
           .operations()
           .forTransaction(transactionResponse.getHash())
-          .execute()
+          .limit(HorizonServer.HORIZON_PER_REQUEST_LIMIT)
+          .execute(),
+        "transaction.operations"
       );
     } catch (IOException | FormatException e) {
       LOG.error(
@@ -161,6 +163,7 @@ public class AssetSubscriberConfiguration {
     this.server.horizonServer()
         .transactions()
         .cursor(cursorPointer)
+        .limit(HorizonServer.HORIZON_PER_REQUEST_LIMIT)
         .stream(new EventListener<TransactionResponse>() {
           @Override
           public void onEvent(TransactionResponse transactionResponse) {

--- a/src/main/java/io/amberdata/inbound/stellar/configuration/subscribers/OrdersSubscriberConfiguration.java
+++ b/src/main/java/io/amberdata/inbound/stellar/configuration/subscribers/OrdersSubscriberConfiguration.java
@@ -129,6 +129,7 @@ public class OrdersSubscriberConfiguration {
     this.server.horizonServer()
         .ledgers()
         .cursor(cursorPointer)
+        .limit(HorizonServer.HORIZON_PER_REQUEST_LIMIT)
         .stream(new EventListener<LedgerResponse>() {
           @Override
           public void onEvent(LedgerResponse ledgerResponse) {
@@ -151,7 +152,9 @@ public class OrdersSubscriberConfiguration {
         this.server.horizonServer()
           .operations()
           .forLedger(ledgerResponse.getSequence())
-          .execute()
+          .limit(HorizonServer.HORIZON_PER_REQUEST_LIMIT)
+          .execute(),
+        "ledger.operations"
       );
     } catch (IOException | FormatException e) {
       LOG.error(

--- a/src/main/java/io/amberdata/inbound/stellar/configuration/subscribers/StellarSubscriberConfiguration.java
+++ b/src/main/java/io/amberdata/inbound/stellar/configuration/subscribers/StellarSubscriberConfiguration.java
@@ -18,6 +18,7 @@ import java.io.IOException;
 
 import java.math.BigDecimal;
 import java.net.URISyntaxException;
+import java.net.URL;
 import java.time.Duration;
 
 import java.util.ArrayList;
@@ -491,12 +492,12 @@ public class StellarSubscriberConfiguration {
 
     Map<Long, String> effectLookup = new HashMap<>();
     for (EffectResponse effect : effects) {
-      final String operationUri = effect.getLinks().getOperation().getHref();
-      final String[] fields = operationUri.split("/");
+      final URL operationUri = new URL(effect.getLinks().getOperation().getHref());
+      final String[] fields = operationUri.getPath().split("/");
 
       if (fields.length < 2 || !fields[fields.length - 2].equals("operations")) {
         LOG.error("unexpected operation href: {} fields: {} length: {} element: {}", operationUri, (Object)fields, fields.length, fields[fields.length - 2]);
-        throw new RuntimeException("die");
+        throw new RuntimeException("assertion failed for operation id extraction");
       }
 
       final Long operationId = Long.parseLong(fields[fields.length - 1]);

--- a/src/main/java/io/amberdata/inbound/stellar/configuration/subscribers/TradesSubscriberConfiguration.java
+++ b/src/main/java/io/amberdata/inbound/stellar/configuration/subscribers/TradesSubscriberConfiguration.java
@@ -135,6 +135,7 @@ public class TradesSubscriberConfiguration {
     this.server.horizonServer()
         .ledgers()
         .cursor(NOW_CURSOR_POINTER)
+        .limit(HorizonServer.HORIZON_PER_REQUEST_LIMIT)
         .stream(new EventListener<LedgerResponse>() {
           @Override
           public void onEvent(LedgerResponse ledgerResponse) {
@@ -166,7 +167,8 @@ public class TradesSubscriberConfiguration {
     try {
       List<TradeResponse> records = StellarSubscriberConfiguration.getObjects(
           this.server,
-          requestBuilder.execute()
+          requestBuilder.execute(),
+          "trades"
       );
       if (records.isEmpty()) {
         return Collections.emptyList();

--- a/src/main/java/io/amberdata/inbound/stellar/configuration/subscribers/TransactionsSubscriberConfiguration.java
+++ b/src/main/java/io/amberdata/inbound/stellar/configuration/subscribers/TransactionsSubscriberConfiguration.java
@@ -120,7 +120,9 @@ public class TransactionsSubscriberConfiguration {
         this.server.horizonServer()
           .operations()
           .forTransaction(transactionResponse.getHash())
-          .execute()
+          .limit(HorizonServer.HORIZON_PER_REQUEST_LIMIT)
+          .execute(),
+          "transaction.operations"
         );
     } catch (IOException | FormatException e) {
       LOG.error(
@@ -144,6 +146,7 @@ public class TransactionsSubscriberConfiguration {
     this.server.horizonServer()
         .transactions()
         .cursor(cursorPointer)
+        .limit(HorizonServer.HORIZON_PER_REQUEST_LIMIT)
         .stream(new EventListener<TransactionResponse>() {
           @Override
           public void onEvent(TransactionResponse transactionResponse) {

--- a/src/main/java/io/amberdata/inbound/stellar/mapper/operations/AccountMergeOperationMapper.java
+++ b/src/main/java/io/amberdata/inbound/stellar/mapper/operations/AccountMergeOperationMapper.java
@@ -33,12 +33,12 @@ public class AccountMergeOperationMapper implements OperationMapper {
     AccountMergeOperationResponse response = (AccountMergeOperationResponse) operationResponse;
 
     final String from = response.getAccount();
-    if (from == null || from == "") {
+    if (from == null || from.isEmpty()) {
       LOG.warn("Source account in AccountMergeOperationResponse is null or empty");
     }
 
     final String into = response.getInto();
-    if (into == null || into == "") {
+    if (into == null || into.isEmpty()) {
       LOG.warn("Destination account in AccountMergeOperationResponse is null or empty");
     }
 

--- a/src/main/java/io/amberdata/inbound/stellar/mapper/operations/AccountMergeOperationMapper.java
+++ b/src/main/java/io/amberdata/inbound/stellar/mapper/operations/AccountMergeOperationMapper.java
@@ -4,8 +4,6 @@ import io.amberdata.inbound.domain.Asset;
 import io.amberdata.inbound.domain.FunctionCall;
 import io.amberdata.inbound.stellar.client.HorizonServer;
 
-import java.io.IOException;
-
 import java.math.BigDecimal;
 
 import java.util.Collections;
@@ -34,40 +32,36 @@ public class AccountMergeOperationMapper implements OperationMapper {
   public FunctionCall map(OperationResponse operationResponse) {
     AccountMergeOperationResponse response = (AccountMergeOperationResponse) operationResponse;
 
-    if (response.getAccount() == null) {
-      LOG.warn("Source account in AccountMergeOperationResponse is null");
+    final String from = response.getAccount();
+    if (from == null || from == "") {
+      LOG.warn("Source account in AccountMergeOperationResponse is null or empty");
     }
 
-    if (response.getInto() == null) {
-      LOG.warn("Destination account in AccountMergeOperationResponse is null");
+    final String into = response.getInto();
+    if (into == null || into == "") {
+      LOG.warn("Destination account in AccountMergeOperationResponse is null or empty");
     }
 
     BigDecimal lumensTransferred = BigDecimal.ZERO;
-    try {
-      AccountResponse accountResponse = this.server.horizonServer()
-          .accounts()
-          .account(response.getAccount());
+    final AccountResponse accountResponse = this.server.fetchAccountDetails(from);
 
+    if (accountResponse != null) {
       for (AccountResponse.Balance balance : accountResponse.getBalances()) {
         if ("native".equals(balance.getAssetType())) {
           lumensTransferred = lumensTransferred.add(new BigDecimal(balance.getBalance()));
         }
       }
-    } catch (Exception e) {
-      // throw new HorizonServer.StellarException(e.getMessage(), e);
-      LOG.warn(e.getMessage(), e);
-      lumensTransferred = BigDecimal.ZERO;
     }
 
     return new FunctionCall.Builder()
-      .from             (this.fetchAccountId(response.getAccount()))
-      .to               (this.fetchAccountId(response.getInto()))
+      .from             (this.fetchAccountId(from))
+      .to               (this.fetchAccountId(into))
       .type             (AccountMergeOperation.class.getSimpleName())
       .lumensTransferred(lumensTransferred)
       .signature        ("account_merge(account_id)")
       .arguments        (
         Collections.singletonList(
-          FunctionCall.Argument.from("destination", this.fetchAccountId(response.getInto()))
+          FunctionCall.Argument.from("destination", this.fetchAccountId(into))
         )
       )
       .build();

--- a/src/main/java/io/amberdata/inbound/stellar/mapper/operations/PathPaymentOperationMapper.java
+++ b/src/main/java/io/amberdata/inbound/stellar/mapper/operations/PathPaymentOperationMapper.java
@@ -14,9 +14,9 @@ import java.util.Map;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import org.stellar.sdk.PathPaymentOperation;
+import org.stellar.sdk.PathPaymentStrictReceiveOperation;
 import org.stellar.sdk.responses.operations.OperationResponse;
-import org.stellar.sdk.responses.operations.PathPaymentOperationResponse;
+import org.stellar.sdk.responses.operations.PathPaymentStrictReceiveOperationResponse;
 
 public class PathPaymentOperationMapper implements OperationMapper {
 
@@ -32,19 +32,19 @@ public class PathPaymentOperationMapper implements OperationMapper {
   @Override
   @SuppressWarnings("checkstyle:MethodParamPad")
   public FunctionCall map(OperationResponse operationResponse) {
-    PathPaymentOperationResponse response =
-        (PathPaymentOperationResponse) operationResponse;
+    PathPaymentStrictReceiveOperationResponse response =
+        (PathPaymentStrictReceiveOperationResponse) operationResponse;
 
     if (response.getAsset() == null) {
-      LOG.warn("Asset in PathPaymentOperationResponse is null");
+      LOG.warn("Asset in PathPaymentStrictReceiveOperationResponse is null");
     }
 
     if (response.getFrom() == null) {
-      LOG.warn("Source account in PathPaymentOperationResponse is null");
+      LOG.warn("Source account in PathPaymentStrictReceiveOperationResponse is null");
     }
 
     if (response.getTo() == null) {
-      LOG.warn("Destination account in PathPaymentOperationResponse is null");
+      LOG.warn("Destination account in PathPaymentStrictReceiveOperationResponse is null");
     }
 
     Asset asset       = this.assetMapper.map(response.getAsset());
@@ -66,7 +66,7 @@ public class PathPaymentOperationMapper implements OperationMapper {
     return new FunctionCall.Builder()
         .from             (this.fetchAccountId(response.getFrom()))
         .to               (to)
-        .type             (PathPaymentOperation.class.getSimpleName())
+        .type             (PathPaymentStrictReceiveOperation.class.getSimpleName())
         .assetType        (asset.getCode())
         .value            (response.getAmount())
         .lumensTransferred(lumensTransferred)
@@ -93,8 +93,8 @@ public class PathPaymentOperationMapper implements OperationMapper {
 
   @Override
   public List<Asset> getAssets(OperationResponse operationResponse) {
-    PathPaymentOperationResponse response =
-        (PathPaymentOperationResponse) operationResponse;
+    PathPaymentStrictReceiveOperationResponse response =
+        (PathPaymentStrictReceiveOperationResponse) operationResponse;
 
     Asset asset       = this.assetMapper.map(response.getAsset());
     Asset sourceAsset = this.assetMapper.map(response.getSourceAsset());
@@ -103,8 +103,8 @@ public class PathPaymentOperationMapper implements OperationMapper {
   }
 
   private Map<String, Object> getOptionalProperties(
-      PathPaymentOperationResponse response,
-      Asset                        asset
+      PathPaymentStrictReceiveOperationResponse response,
+      Asset                                     asset
   ) {
     Asset sourceAsset = this.assetMapper.map(response.getSourceAsset());
 


### PR DESCRIPTION
Goals of this change:
* Upgrade to Stellar SDK 0.18
* Prepare to backfill all Stellar ledgers from ledger 30191537

What we changed:
* Certain SDK changes required changing some types to their 'strict'
  versions (see [SDK release notes].)
* Added lots of metrics and profiling hooks everywhere as it took more
  than 5 seconds to ingest many ledgers.
* As a result of profiling, zeroed in on a few things that made a
  difference:
  - Fetching account IDs using a LRU cache instead of every single time
    it's referenced
  - Pagination of API requests set to 200 instead of default 10
  - Stellar SDK has an endpoint to fetch associated operation effects
    with a transaction. Since we only use the effects as a joined string
    array, use that endpoint so we can calculate it using 1 request : 1
    transaction rather than fetching effects for every single operation.

How we'll accomplish the backfill:
* As a result of changes, it takes about 3 seconds to backfill a ledger.
* We'll clone this setup a couple times and run them in parallel over
  disjoint ledger ranges.
* We'll delete all but one clone in the end and use it as the active
  subscriber.

Bonus:
* Fix Travis CI by designating JDK8.

[SDK release notes]: https://github.com/stellar/java-stellar-sdk/releases/tag/0.11.0